### PR TITLE
Add force-sync for hidden files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ ENV USER=$USER \
     NC_TRUST_CERT=false \
     NC_SOURCE_DIR="/media/nextcloud/" \
     NC_SILENT=false \
-    NC_EXIT=false
+    NC_EXIT=false   \
+    NC_HIDDEN=false
 
 
 # create group and user

--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ whether or not trust self signed certificates or invalid certificates
 
 default: false
 
+##### NC_HIDDEN
+whether or not nextcloud should be forced to sync hidden files
+
+default: false
+
 
 Any comment or propblem feel free to [fill an issue](https://github.com/juanitomint/nextcloud-client-docker/issues/new) or make a PR!
 

--- a/run.sh
+++ b/run.sh
@@ -7,7 +7,7 @@
 while true
 do
 
-	nextcloudcmd $( [ "$NC_SILENT" == true ] && echo "--silent" ) $( [ "$NC_TRUST_CERT" == true ] && echo "--trust" ) --non-interactive -u $NC_USER -p $NC_PASS $NC_SOURCE_DIR $NC_URL
+	nextcloudcmd $( [ "$NC_HIDDEN" == true ] && echo "-h" ) $( [ "$NC_SILENT" == true ] && echo "--silent" ) $( [ "$NC_TRUST_CERT" == true ] && echo "--trust" ) --non-interactive -u $NC_USER -p $NC_PASS $NC_SOURCE_DIR $NC_URL
 	
 	#chown the files to the USER_UID:
 	echo "chown -R $USER_UID:$USER_GID $NC_SOURCE_DIR";


### PR DESCRIPTION
nextcloudcmd has a `-h` option. It is documented [here](https://docs.nextcloud.com/desktop/2.5/advancedusage.html#nextcloud-command-line-client).
On some docker hosts (e.g. my unRaid server) hidden files are somehow not synced by default. Using this option you can force nextcloud to sync them.
I added a environment variable for it and added a quick info in the README.