### PR TITLE
run sync with sudo instead of chown afterwards

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,8 @@ ENV USER=$USER \
     NC_HIDDEN=false
 
 
-# create group and user
-RUN addgroup -g $USER_GID $USER && adduser -G $USER -D -u $USER_UID $USER
-
 # update repositories and install nextcloud-client
-RUN apk update && apk add nextcloud-client moreutils && rm -rf /etc/apk/cache
+RUN apk update && apk add nextcloud-client moreutils sudo && rm -rf /etc/apk/cache
 
 # add run script
 ADD run.sh /usr/bin/run.sh

--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,9 @@ if [ -z $NC_USER ] || [ -z $NC_PASS ] || [ -z $NC_URL ]; then
   exit 1
 fi
 
+getent group $USER_GID > /dev/null || addgroup -g $USER_GID $USER
+getent passwd $USER_UID > /dev/null || adduser -u $USER_UID $USER -D -H -G $USER
+
 [ -d /settings ] || mkdir -p /settings
 chown -R $USER_UID:$USER_GID /settings
 
@@ -45,11 +48,9 @@ do
 	[ "$EXCLUDE" ] && set -- "$@" "--exclude" "$EXCLUDE"
 	[ "$UNSYNCEDFOLDERS" ] && set -- "$@" "--unsyncedfolders" "$UNSYNCEDFOLDERS"
 	set -- "$@" "--non-interactive" "-u" "$NC_USER" "-p" "$NC_PASS" "$NC_SOURCE_DIR" "$NC_URL"
-	nextcloudcmd "$@"
+	sudo -u \#$USER_UID -g \#$USER_GID nextcloudcmd "$@"
 
 	[ "$NC_SILENT" == true ] && echo "[ info run.sh ]: Sync done" | ts "${LOG_DATE_FORMAT}"
-	echo "[ info run.sh ]: chown -R $USER_UID:$USER_GID $NC_SOURCE_DIR" | ts "${LOG_DATE_FORMAT}"
-	chown -R $USER_UID:$USER_GID $NC_SOURCE_DIR
 
 	#check if exit!
 	if [ "$NC_EXIT" = true ] ; then


### PR DESCRIPTION
This fixes https://github.com/juanitomint/nextcloud-client-docker/issues/8

Instead of running chown recursive over all files after the sync the sync is started with the given uid and gid.

For sudo this user and group need to exist, therefore they are created in run.sh if no user and group with those id exists.

Since the user and group is only used in run.sh and the uid and gid can be overriden when the container is created, it is now created in run.sh instead of image build time.